### PR TITLE
Add number_of_rate_limiter_enabled_nodes option to support scale out use cases

### DIFF
--- a/slack_discovery_sdk/base_client.py
+++ b/slack_discovery_sdk/base_client.py
@@ -40,6 +40,7 @@ class BaseDiscoveryClient:
     default_params: Dict[str, str]
     logger: Logger
     rate_limit_error_prevention_enabled: bool
+    number_of_rate_limiter_enabled_nodes: int
     rate_limiter: RateLimiter
 
     def __init__(
@@ -56,6 +57,7 @@ class BaseDiscoveryClient:
         team_id: Optional[str] = None,
         logger: Optional[logging.Logger] = None,
         rate_limit_error_prevention_enabled: bool = True,
+        number_of_rate_limiter_enabled_nodes: int = 1,
         rate_limiter: Optional[RateLimiter] = None,
     ):
         self.token = None if token is None else token.strip()
@@ -78,7 +80,15 @@ class BaseDiscoveryClient:
                 self.proxy = env_variable
 
         self.rate_limit_error_prevention_enabled = rate_limit_error_prevention_enabled
-        self.rate_limiter = rate_limiter if rate_limiter is not None else RateLimiter()
+        self.number_of_rate_limiter_enabled_nodes = number_of_rate_limiter_enabled_nodes
+        self.rate_limiter = (
+            rate_limiter
+            if rate_limiter is not None
+            else RateLimiter(
+                enterprise_id=None,
+                number_of_nodes=number_of_rate_limiter_enabled_nodes,
+            )
+        )
 
     def api_call(  # skipcq: PYL-R1710
         self,

--- a/tests/test_rate_limit_scenario.py
+++ b/tests/test_rate_limit_scenario.py
@@ -11,12 +11,15 @@ from concurrent.futures.thread import ThreadPoolExecutor
 class TestEnterprise:
     def setup_method(self):
         self.token = os.environ[SLACK_DISCOVERY_SDK_TEST_ENTERPRISE_TOKEN]
+        self.number_of_nodes = 3  # the default is 1
 
     @pytest.mark.skip
     def test_discovery_users(self):
         executor = ThreadPoolExecutor(max_workers=100)
         client = DiscoveryClient(
-            token=self.token, rate_limit_error_prevention_enabled=True
+            token=self.token,
+            rate_limit_error_prevention_enabled=True,
+            number_of_rate_limiter_enabled_nodes=self.number_of_nodes,
         )
 
         def run():
@@ -37,7 +40,9 @@ class TestEnterprise:
     def test_discovery_conversations_search(self):
         # Very strict rate limit
         client = DiscoveryClient(
-            token=self.token, rate_limit_error_prevention_enabled=True
+            token=self.token,
+            rate_limit_error_prevention_enabled=True,
+            number_of_rate_limiter_enabled_nodes=self.number_of_nodes,
         )
         for i in range(10):
             for search_result in client.discovery_conversations_search(
@@ -73,7 +78,9 @@ class TestEnterprise:
     def test_discovery_conversations_history(self):
         executor = ThreadPoolExecutor(max_workers=20)
         client = DiscoveryClient(
-            token=self.token, rate_limit_error_prevention_enabled=True
+            token=self.token,
+            rate_limit_error_prevention_enabled=True,
+            number_of_rate_limiter_enabled_nodes=self.number_of_nodes,
         )
 
         def run():

--- a/tests/test_rate_limit_support.py
+++ b/tests/test_rate_limit_support.py
@@ -10,32 +10,36 @@ class TestRateLimitSupport:
         pass
 
     def test_cleanup(self):
-        rate_limiter = RateLimiter(enterprise_id="E111")
-        now = time.time()
-        rate_limiter.org_call_histories_in_last_second = [
-            now,
-            now - 0.01,
-            now - 0.03,
-            now - 1.5,
-            now - 3,
+        rate_limiters = [
+            RateLimiter(enterprise_id="E111"),
+            RateLimiter(enterprise_id="E111", number_of_nodes=10),
         ]
-        rate_limiter.api_method_call_histories_in_last_minute = {
-            "discovery.enterprise.info": [
+        for rate_limiter in rate_limiters:
+            now = time.time()
+            rate_limiter.org_call_histories_in_last_second = [
                 now,
-                now - 10,
-                now - 30,
-                now - 100,
-                now - 300,
+                now - 0.01,
+                now - 0.03,
+                now - 1.5,
+                now - 3,
             ]
-        }
-        rate_limiter.cleanup()
-
-        assert len(rate_limiter.org_call_histories_in_last_second) == 3
-        assert (
-            len(
-                rate_limiter.api_method_call_histories_in_last_minute[
-                    "discovery.enterprise.info"
+            rate_limiter.api_method_call_histories_in_last_minute = {
+                "discovery.enterprise.info": [
+                    now,
+                    now - 10,
+                    now - 30,
+                    now - 100,
+                    now - 300,
                 ]
+            }
+            rate_limiter.cleanup()
+
+            assert len(rate_limiter.org_call_histories_in_last_second) == 3
+            assert (
+                len(
+                    rate_limiter.api_method_call_histories_in_last_minute[
+                        "discovery.enterprise.info"
+                    ]
+                )
+                == 3
             )
-            == 3
-        )


### PR DESCRIPTION
As with [the rate limiter support in our Java SDK](https://slack.dev/java-slack-sdk/guides/web-api-basics#rate-limits), the rate limiter support can consider the use case where a developer run multiple instances / processes to distribute the discovery API calls. This pull request introduces a new option to set the number of nodes in the constructor.

