### PR TITLE
Add a script to build a package

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+script_dir=`dirname $0`
+cd ${script_dir}/..
+version=`grep __version__ ./slack_discovery_sdk/version.py | awk -F'"' '{print $2}'`
+while true; do
+    read -p "Do you wish to build a package for version ${version}? (y/N)" yn
+    case $yn in
+        [Yy]* ) make install; break;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+pip install twine wheel && \
+  rm -rf ./dist/ ./build/ *.egg-info/ && \
+  python setup.py sdist bdist_wheel && \
+  twine check dist/*

--- a/slack_discovery_sdk/version.py
+++ b/slack_discovery_sdk/version.py
@@ -1,3 +1,3 @@
 # Copyright 2021, Slack Technologies, LLC. All rights reserved.
 
-__version__ = "0.0.1"
+__version__ = "0.0.4a"


### PR DESCRIPTION
This pull request adds a script to easily build a package file. We can upload the files under `dist` when cutting a release tag.

```
(.venv) $ ./scripts/build.sh
Do you wish to build a package for version 0.0.4a? (y/N)y

make: *** No rule to make target `install'.  Stop.
(omitted)
creating build/bdist.macosx-11-x86_64/wheel/slack_discovery_sdk-0.0.4a0.dist-info/WHEEL
creating 'dist/slack_discovery_sdk-0.0.4a0-py2.py3-none-any.whl' and adding 'build/bdist.macosx-11-x86_64/wheel' to it
adding 'slack_discovery_sdk/__init__.py'
adding 'slack_discovery_sdk/base_client.py'
adding 'slack_discovery_sdk/client.py'
adding 'slack_discovery_sdk/errors.py'
adding 'slack_discovery_sdk/internal_utils.py'
adding 'slack_discovery_sdk/oauth.py'
adding 'slack_discovery_sdk/proxy_support.py'
adding 'slack_discovery_sdk/rate_limit_support.py'
adding 'slack_discovery_sdk/response.py'
adding 'slack_discovery_sdk/version.py'
adding 'slack_discovery_sdk/examples/DLP_call_pattern.py'
adding 'slack_discovery_sdk/examples/__init__.py'
adding 'slack_discovery_sdk/examples/audit_logs_pattern.py'
adding 'slack_discovery_sdk/examples/get_enterprise_info.py'
adding 'slack_discovery_sdk/examples/user_based_eDiscovery_pattern.py'
adding 'slack_discovery_sdk/examples/utils.py'
adding 'slack_discovery_sdk-0.0.4a0.dist-info/LICENSE.md'
adding 'slack_discovery_sdk-0.0.4a0.dist-info/METADATA'
adding 'slack_discovery_sdk-0.0.4a0.dist-info/WHEEL'
adding 'slack_discovery_sdk-0.0.4a0.dist-info/top_level.txt'
adding 'slack_discovery_sdk-0.0.4a0.dist-info/RECORD'
removing build/bdist.macosx-11-x86_64/wheel
Checking dist/slack_discovery_sdk-0.0.4a0-py2.py3-none-any.whl: PASSED
Checking dist/slack-discovery-sdk-0.0.4a0.tar.gz: PASSED

(.venv) $ tree dist/
dist/
├── slack-discovery-sdk-0.0.4a0.tar.gz
└── slack_discovery_sdk-0.0.4a0-py2.py3-none-any.whl

0 directories, 2 files
```