### PR TITLE
Add Python 3.10 to the supported versions

### DIFF
--- a/.github/workflows/simple-validation.yml
+++ b/.github/workflows/simple-validation.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
This pull request adds a CI build job with Python 3.10 and updates the package metadata to have 3.10 in the supported versions.