### PR TITLE
Fix pagination bug where latest is used for offset

### DIFF
--- a/slack_discovery_sdk/response.py
+++ b/slack_discovery_sdk/response.py
@@ -14,6 +14,7 @@ _LATEST_OFFSET_APIS = [
     'discovery.conversations.edits',
     'discovery.conversations.renames',
     'discovery.conversations.reactions',
+    'discovery.conversations.recent',
 ]
 
 

--- a/slack_discovery_sdk/response.py
+++ b/slack_discovery_sdk/response.py
@@ -9,6 +9,14 @@ from .errors import DiscoveryApiError  # type:ignore
 from .internal_utils import _next_cursor_is_present  # type:ignore
 
 
+_LATEST_OFFSET_APIS = [
+    'discovery.conversations.history',
+    'discovery.conversations.edits',
+    'discovery.conversations.renames',
+    'discovery.conversations.reactions',
+]
+
+
 class DiscoveryResponse:
     """An iterable container of response data.
     Attributes:
@@ -119,6 +127,9 @@ class DiscoveryResponse:
             params.update({"cursor": next_cursor})
             # offset for https://api.slack.com/enterprise/discovery/methods#users_list etc.
             params.update({"offset": self.body.get("offset")})
+
+            if any([latest_offset_api in self.api_url for latest_offset_api in _LATEST_OFFSET_APIS]):
+                params.update({"latest": self.body.get("offset")})
 
             response = self._client.fetch_next_page(  # skipcq: PYL-W0212
                 http_method=self.http_method,

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -1,7 +1,7 @@
 # Copyright 2021, Slack Technologies, LLC. All rights reserved.
 from typing import Any
 
-import os, pytest, time
+import os, pytest, time, json
 from slack_sdk import WebClient
 from slack_discovery_sdk import DiscoveryClient
 from slack_discovery_sdk.internal_utils import (
@@ -90,6 +90,21 @@ class TestConversations:
             if page_num > 5:
                 break
         assert len(conversations) > limit_size
+
+    def test_conversations_history_pagination(self):
+        conversations = []
+        limit_size = 1
+        page_num = 0
+        for page in self.client.discovery_conversations_history(channel=self.channel, team=self.team, limit=limit_size):
+            for message in page['messages']:
+                conversations.append(json.dumps(message))
+            page_num += 1
+            if page_num > 5:
+                break
+
+        assert len(conversations) > limit_size
+        # ensure we are getting different messages for each page
+        assert sorted(set(conversations)) == sorted(conversations)
 
     def test_conversations_history_from_one_minute_ago(self):
         test_text = "This first message will be used to test getting conversation history from the last minute"


### PR DESCRIPTION
`DiscoveryResponse.__iter__` does not handle the case where `latest` parameter is used as the `offset` for APIs where `offset` parameter doesn't exist but `latest` is used as documented instead.  

These apis are:

- `discovery.conversations.history`
- `discovery.conversations.edits`
- `discovery.conversations.renames`
- `discovery.conversations.reactions`

This PR adds support and tests