### PR TITLE
ci: pin actions workflow step hashes and use minimum permissions

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,7 +2,8 @@ name: Lint validation using flake8
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -11,19 +12,24 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version:
+          - "3.9"
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install -e ".[testing]"
-        # We manually upgrade it to make the builds stable
-        pip install "flake8==6.1.0"
-    - name: Run flake8
-      run: |
-        flake8 slack_discovery_sdk/
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e ".[testing]"
+          # We manually upgrade it to make the builds stable
+          pip install "flake8==6.1.0"
+      - name: Run flake8
+        run: |
+          flake8 slack_discovery_sdk/

--- a/.github/workflows/py_compile.yml
+++ b/.github/workflows/py_compile.yml
@@ -2,7 +2,8 @@ name: Sytanx check using py_compile
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 jobs:
   build:
@@ -10,21 +11,29 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version:
+          - "3.11"
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install -e ".[testing]"
-    - name: Run py_compile for main code
-      run: |
-        find slack_discovery_sdk -name '*.py' | xargs python -m py_compile
-    - name: Run py_compile for test code
-      run: |
-        find tests -name '*.py' | xargs python -m py_compile
-
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e ".[testing]"
+      - name: Run py_compile for main code
+        run: |
+          find slack_discovery_sdk -name '*.py' | xargs python -m py_compile
+      - name: Run py_compile for test code
+        run: |
+          find tests -name '*.py' | xargs python -m py_compile

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -2,7 +2,8 @@ name: Type hint validation using pytype
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -11,19 +12,24 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version:
+          - "3.9"
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install -U pip
-        pip install -e ".[testing]"
-        # As pytype can change its behavior in newer versions, we manually upgrade it
-        pip install "pytype==2023.9.27"
-    - name: Run pytype
-      run: |
-        pytype slack_discovery_sdk/
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e ".[testing]"
+          # As pytype can change its behavior in newer versions, we manually upgrade it
+          pip install "pytype==2023.9.27"
+      - name: Run pytype
+        run: |
+          pytype slack_discovery_sdk/


### PR DESCRIPTION
> ⚠️ This is part of a maintenance update to ensure CI remains updated and in a working state.

### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾 

### Reviewers

A similar audit can be performed with the `zizmor` tool:

```sh
$ zizmor .
...
No findings to report. Good job! (1 ignored, 4 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.