### PR TITLE
client: fix 'occured' -> 'occurred' in docstring

### DIFF
--- a/slack_discovery_sdk/client.py
+++ b/slack_discovery_sdk/client.py
@@ -348,7 +348,7 @@ class DiscoveryClient(BaseDiscoveryClient):
         private: Optional[bool] = None,
         **kwargs,
     ) -> DiscoveryResponse:
-        """You can use this endpoint to gather all channel renames that have occured for an org,
+        """You can use this endpoint to gather all channel renames that have occurred for an org,
         without having to call the discovery.conversations.info endpoint for each channel.
         Refer to https://api.slack.com/enterprise/discovery/methods#conversations_renames for more details.
         """


### PR DESCRIPTION
Docstring in `slack_discovery_sdk/client.py` line 351 reads `renames that have occured`. Fixed to `occurred`. Comment-only change.